### PR TITLE
Update to bosh-cli/2.0.48 for gcs fixes

### DIFF
--- a/pipelines/release-tpl.yml
+++ b/pipelines/release-tpl.yml
@@ -54,8 +54,8 @@ jobs:
         - -c
         - |
           set -eu
-          wget -O /usr/bin/bosh https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.28-linux-amd64
-          echo "7b7629fcdf8839cf29bf25d97e8ea6beb3b9a7b2  /usr/bin/bosh" | shasum -c -
+          wget -O /usr/bin/bosh https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.48-linux-amd64
+          echo "c807f1938494f4280d65ebbdc863eda3f883d72e  /usr/bin/bosh" | shasum -c -
           chmod +x /usr/bin/bosh
           wget -O /usr/bin/meta4 https://s3.amazonaws.com/dk-shared-assets/meta4-0.1.0-linux-amd64
           echo "235bc60706793977446529830c2cb319e6aaf2da  /usr/bin/meta4" | shasum -c -


### PR DESCRIPTION
https://main.bosh-ci.cf-app.com/teams/bosh-io/pipelines/release:github.com:cloudfoundry:nats-release/jobs/create-release/builds/5

Presumably related to their detection of credentials on public buckets. https://github.com/cloudfoundry/bosh-cli/issues/363