### PR TITLE
Switch custom resource types to registry-image

### DIFF
--- a/src/worker/pipelines/org.go
+++ b/src/worker/pipelines/org.go
@@ -157,7 +157,7 @@ func (op *OrgPipeline) AddRelease(r releases.Release) {
 							Config: &atc.TaskConfig{
 								Platform: "linux",
 								ImageResource: &atc.ImageResource{
-									Type: "docker-image",
+									Type: "registry-image",
 									Source: atc.Source{
 										"repository": "bosh/integration",
 									},


### PR DESCRIPTION
Using docker-image for the type was leading to a cloudflare challenge when checking.

(already flown)